### PR TITLE
[FEAT] 북마크 조회 API

### DIFF
--- a/prisma/migrations/20250718102811_add_cascade_delete_commission/migration.sql
+++ b/prisma/migrations/20250718102811_add_cascade_delete_commission/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE `bookmarks` DROP FOREIGN KEY `bookmarks_commission_id_fkey`;
+
+-- DropForeignKey
+ALTER TABLE `commission_tags` DROP FOREIGN KEY `commission_tags_tag_id_fkey`;
+
+-- DropIndex
+DROP INDEX `bookmarks_commission_id_fkey` ON `bookmarks`;
+
+-- DropIndex
+DROP INDEX `commission_tags_tag_id_fkey` ON `commission_tags`;
+
+-- AddForeignKey
+ALTER TABLE `bookmarks` ADD CONSTRAINT `bookmarks_commission_id_fkey` FOREIGN KEY (`commission_id`) REFERENCES `commissions`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `commission_tags` ADD CONSTRAINT `commission_tags_tag_id_fkey` FOREIGN KEY (`tag_id`) REFERENCES `tags`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,7 +235,7 @@ model Bookmark {
   createdAt    DateTime @default(now()) @map("created_at")
 
   user       User       @relation(fields: [userId], references: [id])
-  commission Commission @relation(fields: [commissionId], references: [id])
+  commission Commission @relation(fields: [commissionId], references: [id], onDelete: Cascade)
 
   @@unique([userId, commissionId])
   @@map("bookmarks")
@@ -255,7 +255,7 @@ model CommissionTag {
   tagId        BigInt @map("tag_id")
 
   commission Commission @relation(fields: [commissionId], references: [id])
-  tag        Tag        @relation(fields: [tagId], references: [id])
+  tag        Tag        @relation(fields: [tagId], references: [id], onDelete: Cascade)
 
   @@id([commissionId, tagId])
   @@map("commission_tags")

--- a/src/bookmark/bookmark.route.js
+++ b/src/bookmark/bookmark.route.js
@@ -3,6 +3,7 @@ import {
   addBookmark,
   deleteBookmark,
   deleteSelectedBookmarks,
+  getBookmarks
 } from "./controller/bookmark.controller.js";
 import { authenticate } from "../middlewares/auth.middleware.js";
 
@@ -10,6 +11,9 @@ const router = Router();
 
 // 북마크 추가 API
 router.post('/commissions/:commissionId/bookmarks', authenticate, addBookmark);
+
+// 북마크 목록 조회 API
+router.get('/bookmarks', authenticate, getBookmarks);
 
 // 북마크 삭제 API
 router.delete("/commissions/:commissionId/bookmarks/:bookmarkId", authenticate, deleteBookmark);

--- a/src/bookmark/controller/bookmark.controller.js
+++ b/src/bookmark/controller/bookmark.controller.js
@@ -1,10 +1,10 @@
-// controllers/bookmarkController.js
 import { StatusCodes } from "http-status-codes";
 import { BookmarkService } from '../service/bookmark.service.js';
 import {
   CreateBookmarkDto,
   DeleteBookmarkDto,
-  DeleteSelectedBookmarksDto
+  DeleteSelectedBookmarksDto,
+  GetBookmarksDto
 } from "../dto/bookmark.dto.js";
 import { parseWithBigInt, stringifyWithBigInt } from "../../bigintJson.js";
 
@@ -69,3 +69,28 @@ export async function deleteSelectedBookmarks(req, res, next) {
     next(err);
   }
 }
+
+// 북마크 목록 조회
+export const getBookmarks = async (req, res, next) => {
+  try {
+    const userId = BigInt(req.user.userId);
+    const dto = new GetBookmarksDto({
+      sort: req.query.sort,
+      limit: req.query.limit ? parseInt(req.query.limit) : undefined,
+      cursor: req.query.cursor,
+      excludeFullSlots: req.query.excludeFullSlots === 'true'
+    });
+
+    const bookmarks = await BookmarkService.getBookmarks(userId, dto);
+    const json = stringifyWithBigInt({
+      resultType: "SUCCESS",
+      error: null,
+      success: bookmarks
+    });
+
+    res.setHeader("Content-Type", "application/json");
+    res.status(StatusCodes.OK).send(json);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/bookmark/dto/bookmark.dto.js
+++ b/src/bookmark/dto/bookmark.dto.js
@@ -1,9 +1,11 @@
+// 북마크 추가 dto
 export class CreateBookmarkDto {
   constructor({ commissionId }) {
     this.commissionId = commissionId;
   }
 }
 
+// 북마크 삭제 dto
 export class DeleteBookmarkDto {
   constructor({ commissionId, bookmarkId }) {
     this.commissionId = commissionId;
@@ -11,8 +13,19 @@ export class DeleteBookmarkDto {
   }
 }
 
+// 북마크 선택 삭제 dto
 export class DeleteSelectedBookmarksDto {
   constructor({ bookmarkIds }) {
     this.bookmarkIds = bookmarkIds;
+  }
+}
+
+// 사용자 북마크 조회 dto
+export class GetBookmarksDto {
+  constructor({ sort, limit, cursor, excludeFullSlots }) {
+    this.sort = sort || 'latest';
+    this.limit = limit || 12;
+    this.cursor = cursor || null;
+    this.excludeFullSlots = excludeFullSlots || false;
   }
 }

--- a/src/bookmark/repository/bookmark.repository.js
+++ b/src/bookmark/repository/bookmark.repository.js
@@ -73,7 +73,7 @@ export const BookmarkRepository = {
    * 사용자의 북마크 목록 조회 (커서 기반 페이징)
    */
   async findBookmarksByUserId(userId, dto) {
-    const { sort, limit, cursor } = dto;
+    const { sort, limit, cursor, excludeFullSlots = false } = dto;
 
     const baseCondition = {
     userId: BigInt(userId)
@@ -165,7 +165,7 @@ export const BookmarkRepository = {
         }
       },
       orderBy,
-      take: limit + 1, // hasNext 확인용
+      take: excludeFullSlots ? 100 : limit + 1, // hasNext 확인용
     });
   },
 

--- a/src/bookmark/repository/bookmark.repository.js
+++ b/src/bookmark/repository/bookmark.repository.js
@@ -68,4 +68,129 @@ export const BookmarkRepository = {
       },
     });
   },
+
+  /**
+   * 사용자의 북마크 목록 조회 (커서 기반 페이징)
+   */
+  async findBookmarksByUserId(userId, dto) {
+    const { sort, limit, cursor } = dto;
+
+    const baseCondition = {
+    userId: BigInt(userId)
+    };
+
+    let whereCondition = { ...baseCondition };
+    let orderBy = [];
+    
+    if (cursor) {
+      const decodedCursor = JSON.parse(Buffer.from(cursor, 'base64').toString());
+      switch (sort) {
+        case 'latest': // 최신순 정렬
+          whereCondition.createdAt = { lt: new Date(decodedCursor.created_at) };
+          orderBy = [{ createdAt: 'desc' }, { id: 'desc' }];
+          break;
+        case 'price_low': // 저가순 정렬
+          whereCondition.OR = [
+            { commission: { minPrice: { gt: decodedCursor.min_price } } },
+            { 
+              commission: { minPrice: decodedCursor.min_price },
+              createdAt: { lt: new Date(decodedCursor.created_at) }
+            }
+          ];
+          orderBy = [{ commission: { minPrice: 'asc' } }, { createdAt: 'desc' }];
+          break;
+        case 'price_high': // 고가순 정렬
+          whereCondition.OR = [
+            { commission: { minPrice: { lt: decodedCursor.min_price } } },
+            { 
+              commission: { minPrice: decodedCursor.min_price },
+              createdAt: { lt: new Date(decodedCursor.created_at) }
+            }
+          ];
+          orderBy = [{ commission: { minPrice: 'desc' } }, { createdAt: 'desc' }];
+          break;
+      }
+    } else {
+      switch (sort) {
+        case 'latest':
+          orderBy = [{ createdAt: 'desc' }, { id: 'desc' }];
+          break;
+        case 'price_low':
+          orderBy = [{ commission: { minPrice: 'asc' } }, { createdAt: 'desc' }];
+          break;
+        case 'price_high':
+          orderBy = [{ commission: { minPrice: 'desc' } }, { createdAt: 'desc' }];
+          break;
+      }
+    }
+
+    return await prisma.bookmark.findMany({
+      where: whereCondition,
+      include: {
+        commission: {
+          include: {
+            category: {
+              select: {
+                id: true,
+                name: true
+              }
+            },
+            commissionTags: {
+              include: {
+                tag: {
+                  select: {
+                    id: true,
+                    name: true
+                  }
+                }
+              }
+            },
+            artist: {
+              select: {
+                id: true,
+                nickname: true,
+                profileImage: true,
+                slot: true
+              }
+            },
+            requests: { // 남은 슬롯 계산
+              where: { 
+                status: { 
+                  in: ['APPROVED', 'IN_PROGRESS', 'SUBMITTED'] 
+                } 
+              },
+              select: { id: true }
+            }
+          }
+        }
+      },
+      orderBy,
+      take: limit + 1, // hasNext 확인용
+    });
+  },
+
+  /**
+   * 사용자의 총 북마크 수 조회
+   */
+  async countBookmarksByUserId(userId) {
+    return await prisma.bookmark.count({
+      where: { 
+        userId: BigInt(userId)
+      }
+    });
+  },
+
+  /**
+   * 커미션 게시글의 썸네일 조회
+   */
+  async findThumbnailImageByCommissionId(commissionId) {
+    return await prisma.image.findFirst({
+      where: {
+        target: 'commission',
+        targetId: BigInt(commissionId),
+        orderIndex: 0
+      },
+      select: { imageUrl: true }
+    });
+  },
 };

--- a/src/bookmark/repository/bookmark.repository.js
+++ b/src/bookmark/repository/bookmark.repository.js
@@ -181,6 +181,33 @@ export const BookmarkRepository = {
   },
 
   /**
+   * 사용자의 슬롯이 남은 북마크 수 조회 (excludeFullSlots=true용)
+  */
+  async countAvailableBookmarksByUserId(userId) {
+    // 모든 북마크를 가져와서 슬롯 계산 후 필터링
+    const bookmarks = await prisma.bookmark.findMany({
+      where: { userId: BigInt(userId) },
+     include: {
+        commission: {
+          include: {
+            artist: { select: { slot: true } },
+            requests: {
+              where: { status: { in: ['APPROVED', 'IN_PROGRESS', 'SUBMITTED'] } },
+            select: { id: true }
+            }
+          }
+        }
+     }
+    });
+
+    // remainingSlots > 0인 것만 카운트
+    return bookmarks.filter(bookmark => {
+      const remainingSlots = bookmark.commission.artist.slot - bookmark.commission.requests.length;
+      return remainingSlots > 0;
+    }).length;
+  },  
+
+  /**
    * 커미션 게시글의 썸네일 조회
    */
   async findThumbnailImageByCommissionId(commissionId) {

--- a/src/bookmark/service/bookmark.service.js
+++ b/src/bookmark/service/bookmark.service.js
@@ -100,65 +100,67 @@ export const BookmarkService = {
 
     const bookmarks = await BookmarkRepository.findBookmarksByUserId(userId, dto);
     
-    const hasNext = bookmarks.length > limit;
-    const items = hasNext ? bookmarks.slice(0, -1) : bookmarks;
-
     const totalCount = excludeFullSlots 
     ? await BookmarkRepository.countAvailableBookmarksByUserId(userId)
     : await BookmarkRepository.countBookmarksByUserId(userId);
 
-    // nextCursor 생성
-    let nextCursor = null;
-    if (hasNext && items.length > 0) {
-      const lastItem = items[items.length - 1];
-      const cursorData = {
-        id: Number(lastItem.id),
-        created_at: lastItem.createdAt.toISOString()
-      };
-      
-      if (sort === 'price_low' || sort === 'price_high') {
-        cursorData.min_price = lastItem.commission.minPrice;
-      }
-      
-      nextCursor = Buffer.from(JSON.stringify(cursorData)).toString('base64');
-    }
-
-    // 응답 데이터 가공
+    // 응답 데이터 가공 (모든 데이터 포맷팅)
     const formattedItems = await Promise.all(
-      items.map(async (bookmark) => {
-        // 썸네일 이미지 조회
-        const thumbnailImage = await BookmarkRepository.findThumbnailImageByCommissionId(bookmark.commission.id);
-        
-        // 남은 슬롯수 계산
-        const remainingSlots = bookmark.commission.artist.slot - bookmark.commission.requests.length;
+      bookmarks.map(async (bookmark) => {
+      // 썸네일 이미지 조회
+      const thumbnailImage = await BookmarkRepository.findThumbnailImageByCommissionId(bookmark.commission.id);
+      
+      // 남은 슬롯수 계산
+      const remainingSlots = bookmark.commission.artist.slot - bookmark.commission.requests.length;
 
-        return {
-          id: Number(bookmark.commission.id),
-          title: bookmark.commission.title,
-          minPrice: bookmark.commission.minPrice,
-          category: bookmark.commission.category,
-          tags: bookmark.commission.commissionTags.map(ct => ct.tag),
-          thumbnailImageUrl: thumbnailImage?.imageUrl || null,
-          remainingSlots,
-          artist: {
-            id: Number(bookmark.commission.artist.id),
-            nickname: bookmark.commission.artist.nickname,
-            profileImageUrl: bookmark.commission.artist.profileImage
-          }
-        };
-      })
-    );
+      return {
+        id: Number(bookmark.commission.id),
+        title: bookmark.commission.title,
+        minPrice: bookmark.commission.minPrice,
+        category: bookmark.commission.category,
+        tags: bookmark.commission.commissionTags.map(ct => ct.tag),
+        thumbnailImageUrl: thumbnailImage?.imageUrl || null,
+        remainingSlots,
+        artist: {
+          id: Number(bookmark.commission.artist.id),
+          nickname: bookmark.commission.artist.nickname,
+          profileImageUrl: bookmark.commission.artist.profileImage
+        }
+      };
+    })
+  );
 
-    // 마감 커미션 제외 토글 상태에 따라 필터링
     const filteredItems = excludeFullSlots 
     ? formattedItems.filter(item => item.remainingSlots > 0)
     : formattedItems;
+
+    const hasNext = filteredItems.length > limit;
+    const finalItems = hasNext ? filteredItems.slice(0, -1) : filteredItems;
+
+  // nextCursor 생성
+  let nextCursor = null;
+  if (hasNext && finalItems.length > 0) {
+    const lastFormattedItem = finalItems[finalItems.length - 1];
+    const originalBookmark = bookmarks.find(b => Number(b.commission.id) === lastFormattedItem.id);
+    
+    const cursorData = {
+     id: lastFormattedItem.id,
+     created_at: originalBookmark.createdAt.toISOString()
+    };
+  
+    if (sort === 'price_low' || sort === 'price_high') {
+      cursorData.min_price = lastFormattedItem.minPrice;
+    }
+  
+    nextCursor = Buffer.from(JSON.stringify(cursorData)).toString('base64');
+  }
+
 
     return {
       totalCount,
       hasNext,
       nextCursor,
-      items: filteredItems
+      items: finalItems
     };
   },
 };

--- a/src/bookmark/service/bookmark.service.js
+++ b/src/bookmark/service/bookmark.service.js
@@ -103,7 +103,9 @@ export const BookmarkService = {
     const hasNext = bookmarks.length > limit;
     const items = hasNext ? bookmarks.slice(0, -1) : bookmarks;
 
-    const totalCount = await BookmarkRepository.countBookmarksByUserId(userId);
+    const totalCount = excludeFullSlots 
+    ? await BookmarkRepository.countAvailableBookmarksByUserId(userId)
+    : await BookmarkRepository.countBookmarksByUserId(userId);
 
     // nextCursor 생성
     let nextCursor = null;
@@ -153,7 +155,7 @@ export const BookmarkService = {
     : formattedItems;
 
     return {
-      totalCount: filteredItems.length,
+      totalCount,
       hasNext,
       nextCursor,
       items: filteredItems

--- a/src/bookmark/service/bookmark.service.js
+++ b/src/bookmark/service/bookmark.service.js
@@ -93,4 +93,70 @@ export const BookmarkService = {
       bookmarkIds: validIds,
     };
   },
+
+    // 북마크 목록 조회
+  async getBookmarks(userId, dto) {
+    const { sort, limit, cursor, excludeFullSlots = false } = dto;
+
+    const bookmarks = await BookmarkRepository.findBookmarksByUserId(userId, dto);
+    
+    const hasNext = bookmarks.length > limit;
+    const items = hasNext ? bookmarks.slice(0, -1) : bookmarks;
+
+    const totalCount = await BookmarkRepository.countBookmarksByUserId(userId);
+
+    // nextCursor 생성
+    let nextCursor = null;
+    if (hasNext && items.length > 0) {
+      const lastItem = items[items.length - 1];
+      const cursorData = {
+        id: Number(lastItem.id),
+        created_at: lastItem.createdAt.toISOString()
+      };
+      
+      if (sort === 'price_low' || sort === 'price_high') {
+        cursorData.min_price = lastItem.commission.minPrice;
+      }
+      
+      nextCursor = Buffer.from(JSON.stringify(cursorData)).toString('base64');
+    }
+
+    // 응답 데이터 가공
+    const formattedItems = await Promise.all(
+      items.map(async (bookmark) => {
+        // 썸네일 이미지 조회
+        const thumbnailImage = await BookmarkRepository.findThumbnailImageByCommissionId(bookmark.commission.id);
+        
+        // 남은 슬롯수 계산
+        const remainingSlots = bookmark.commission.artist.slot - bookmark.commission.requests.length;
+
+        return {
+          id: Number(bookmark.commission.id),
+          title: bookmark.commission.title,
+          minPrice: bookmark.commission.minPrice,
+          category: bookmark.commission.category,
+          tags: bookmark.commission.commissionTags.map(ct => ct.tag),
+          thumbnailImageUrl: thumbnailImage?.imageUrl || null,
+          remainingSlots,
+          artist: {
+            id: Number(bookmark.commission.artist.id),
+            nickname: bookmark.commission.artist.nickname,
+            profileImageUrl: bookmark.commission.artist.profileImage
+          }
+        };
+      })
+    );
+
+    // 마감 커미션 제외 토글 상태에 따라 필터링
+    const filteredItems = excludeFullSlots 
+    ? formattedItems.filter(item => item.remainingSlots > 0)
+    : formattedItems;
+
+    return {
+      totalCount: filteredItems.length,
+      hasNext,
+      nextCursor,
+      items: filteredItems
+    };
+  },
 };

--- a/src/common/swagger/bookmark.json
+++ b/src/common/swagger/bookmark.json
@@ -151,58 +151,179 @@
       }
     },
     "/api/bookmarks": {
-      "delete": {
-        "tags": ["Bookmark"],
-        "summary": "북마크 선택 삭제",
-        "description": "마이페이지에서 북마크를 선택 삭제",
-        "security": [
-          {
-          "bearerAuth": []
+  "delete": {
+    "tags": ["Bookmark"],
+    "summary": "북마크 선택 삭제",
+    "description": "마이페이지에서 북마크를 선택 삭제",
+    "security": [
+      {
+        "bearerAuth": []
+      }
+    ],
+    "requestBody": {
+      "required": true,
+      "content": {
+        "application/json": {
+          "schema": {
+            "type": "object",
+            "properties": {
+              "bookmarkIds": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "example": [1, 2, 3]
+              }
+            }
           }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "bookmarkIds": {
-                    "type": "array",
-                    "items": { "type": "integer" },
-                    "example": [1, 2, 3]
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "선택한 북마크 삭제 결과",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "resultType": { "type": "string", "example": "SUCCESS" },
+                "error": { "type": "null", "example": null },
+                "success": {
+                  "type": "object",
+                  "properties": {
+                    "deletedIds": {
+                      "type": "array",
+                      "items": { "type": "integer" },
+                      "example": [1, 2]
+                    },
+                    "notFoundIds": {
+                      "type": "array",
+                      "items": { "type": "integer" },
+                      "example": [3]
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "선택한 북마크가 삭제되었습니다."
+                    }
                   }
                 }
               }
             }
           }
+        }
+      },
+      "207": {
+        "description": "일부 북마크만 삭제됨"
+      }
+    }
+  },
+  "get": {
+    "tags": ["Bookmark"],
+    "summary": "북마크 목록 조회",
+    "description": "사용자의 북마크한 커미션 목록을 조회합니다. 정렬 및 무한스크롤 페이징을 지원합니다.",
+    "security": [
+      {
+        "bearerAuth": []
+      }
+    ],
+    "parameters": [
+      {
+        "name": "sort",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": ["latest", "price_low", "price_high"],
+          "default": "latest"
         },
-        "responses": {
-          "200": {
-            "description": "선택한 북마크 삭제 결과",
-            "content": {
-              "application/json": {
-                "schema": {
+        "description": "정렬 방식"
+      },
+      {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50,
+          "default": 12
+        },
+        "description": "한 번에 가져올 개수"
+      },
+      {
+        "name": "cursor",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "description": "다음 페이지 조회용 커서"
+      },
+      {
+        "name": "excludeFullSlots",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean",
+          "default": false
+        },
+        "description": "남은 슬롯이 0인 커미션 제외 여부"
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "북마크 목록 조회 성공",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "resultType": { "type": "string", "example": "SUCCESS" },
+                "error": { "type": "null", "example": null },
+                "success": {
                   "type": "object",
                   "properties": {
-                    "resultType": { "type": "string", "example": "SUCCESS" },
-                    "error": { "type": "null", "example": null },
-                    "success": {
-                      "type": "object",
-                      "properties": {
-                        "deletedIds": {
-                          "type": "array",
-                          "items": { "type": "integer" },
-                          "example": [1, 2]
-                        },
-                        "notFoundIds": {
-                          "type": "array",
-                          "items": { "type": "integer" },
-                          "example": [3]
-                        },
-                        "message": {
-                          "type": "string",
-                          "example": "선택한 북마크가 삭제되었습니다."
+                    "totalCount": { "type": "integer", "example": 24 },
+                    "hasNext": { "type": "boolean", "example": true },
+                    "nextCursor": { "type": "string", "example": "eyJpZCI6MTIzLCJjcmVhdGVkX2F0IjoiMjAyNS0wNy0wMVQxMDowMDowMCJ9" },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "example": 1 },
+                          "title": { "type": "string", "example": "커미션 제목" },
+                          "minPrice": { "type": "integer", "example": 10000 },
+                          "category": {
+                            "type": "object",
+                              "properties": {
+                                "id": { "type": "integer", "example": 2 },
+                                "name": { "type": "string", "example": "그림" }
+                              }
+                            },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": { "type": "integer", "example": 1 },
+                                "name": { "type": "string", "example": "캐릭터" }
+                              }
+                            },
+                            "example": [
+                              { "id": 1, "name": "캐릭터" },
+                              { "id": 2, "name": "LD" }
+                            ]
+                          },
+                          "thumbnailImageUrl": { "type": "string", "example": "https://example.com/image.jpg" },
+                          "remainingSlots": { "type": "integer", "example": 3 },
+                          "artist": {
+                            "type": "object",
+                            "properties": {
+                              "id": { "type": "integer", "example": 10 },
+                              "nickname": { "type": "string", "example": "작가 닉네임" },
+                              "profileImageUrl": { "type": "string", "example": "https://example.com/profile.jpg" }
+                            }
+                          }
                         }
                       }
                     }
@@ -210,12 +331,11 @@
                 }
               }
             }
-          },
-          "207": {
-            "description": "일부 북마크만 삭제됨"
           }
         }
       }
     }
+   }
   }
+ }
 }


### PR DESCRIPTION
## 📝 Description
<!-- 어떤 기능을 구현하거나 변경했는지 간단히 설명해 주세요 -->
북마크 리스트 조회
<!-- 이 PR이 해결하는 이슈 번호 (머지되면 해당 이슈가 자동으로 닫힙니다!) -->
Fixes #33

## ⚙️ Type
<!-- PR의 유형을 선택해 주세요. -->
- [x] 기능 추가 (새로운 API, 서비스 로직 등)
- [ ] 버그 수정 (예외 처리, 동작 오류 등)
- [ ] 리팩토링 (코드 정리, 로직 개선 등)
- [x] 문서 수정 (README, Swagger, 주석 등)
- [ ] 테스트 코드 추가/수정
- [ ] 의존성 추가/수정

## 📂 Summary of Changes
<!-- 어떤 파일을 수정했고 어떤 작업을 했는지 요약해 주세요. -->
- `src/bookmark/*`: 북마크 조회 API 구현
- `prisma/schema.prisma`: CASCADE 옵션 추가로 커미션 삭제 시 관련 북마크 및 커미션-태그 테이블의 데이터 자동 삭제
- `src/common/swagger/bookmark.json`: 북마크 조회 스웨거 문서화

## 👀 To Reviewer
<!-- 리뷰어가 꼭 봐줬으면 하는 부분이나 요청사항이 있다면 적어주세요 -->
<!-- 예: 유효성 검사 방식이 괜찮은지 확인 부탁드립니다 -->
커서 페이징에서 필터링 결과가 요청 개수보다 적게 반환되는 문제를 일단 overfetch 방식으로 해결했습니다
CASCADE 설정을 추가해 커미션 삭제 시 관련 북마크들이 자동으로 정리되도록 개선했습니다

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인해 주세요. -->
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 기능이 정상 동작하는지 테스트했습니다.
- [x] Swagger 문서를 최신 상태로 반영했습니다. (필요 시)