### PR TITLE
[FEAT] 신청함 목록 조회 API

### DIFF
--- a/src/common/errors/request.errors.js
+++ b/src/common/errors/request.errors.js
@@ -11,3 +11,14 @@ export class RequestNotFoundError extends BaseError {
     });
   }
 }
+
+export class InvalidRequestFilterError extends BaseError {
+  constructor(data = null) {
+    super({
+      errorCode: "R002",
+      reason: "유효하지 않은 필터 조건입니다. (all, ongoing, completed 중 하나여야 합니다)",
+      statusCode: 400,
+      data,
+    });
+  }
+}

--- a/src/common/swagger/request.json
+++ b/src/common/swagger/request.json
@@ -1,0 +1,110 @@
+{
+  "paths": {
+    "/api/requests": {
+      "get": {
+        "tags": ["Request"],
+        "summary": "신청 목록 조회",
+        "description": "로그인 사용자의 커미션 신청 목록을 조회합니다.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "schema": { 
+              "type": "string", 
+              "enum": ["all", "ongoing", "completed"],
+              "default": "all"
+            },
+            "description": "필터 조건 (all: 전체, ongoing: 신청중, completed: 신청완료)"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer"},
+            "description": "페이지 번호"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "default": 10 },
+            "description": "페이지당 항목 수"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "신청 목록 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": { "type": "string", "example": "SUCCESS" },
+                    "error": { "type": "null", "example": null },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "requests": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "requestId": { "type": "integer", "example": 1 },
+                              "status": { 
+                                "type": "string", 
+                                "enum": ["PENDING", "APPROVED", "IN_PROGRESS", "SUBMITTED", "COMPLETED", "CANCELED", "REJECTED"],
+                                "example": "IN_PROGRESS" 
+                              },
+                              "title": { "type": "string", "example": "낙서 타입 커미션" },
+                              "price": { "type": "integer", "example": 40000 },
+                              "thumbnailImageUrl": { 
+                                "type": "string", 
+                                "nullable": true,
+                                "example": "https://cdn.com/thumbnail.jpg" 
+                              },
+                              "progressPercent": { 
+                                "type": "integer", 
+                                "nullable": true,
+                                "example": 50,
+                                "description": "진행률 (0, 50, 100 또는 null)"
+                              },
+                              "createdAt": { "type": "string", "format": "date-time", "example": "2025-07-01T10:00:00.000Z" },
+                              "artist": {
+                                "type": "object",
+                                "properties": {
+                                  "id": { "type": "integer", "example": 10 },
+                                  "nickname": { "type": "string", "example": "키르" }
+                                }
+                              },
+                              "commission": {
+                                "type": "object",
+                                "properties": {
+                                  "id": { "type": "integer", "example": 5 }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pagination": {
+                          "type": "object",
+                          "properties": {
+                            "page": { "type": "integer", "example": 1 },
+                            "limit": { "type": "integer", "example": 10 },
+                            "totalCount": { "type": "integer", "example": 25 },
+                            "totalPages": { "type": "integer", "example": 3 }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/request/controller/request.controller.js
+++ b/src/request/controller/request.controller.js
@@ -1,0 +1,23 @@
+import { StatusCodes } from "http-status-codes";
+import { RequestService } from '../service/request.service.js';
+import { GetRequestListDto } from "../dto/request.dto.js";
+import { parseWithBigInt, stringifyWithBigInt } from "../../bigintJson.js";
+
+// 신청 목록 조회
+export const getRequestList = async (req, res, next) => {
+  try {
+    const userId = BigInt(req.user.userId);
+    const dto = new GetRequestListDto({
+      filter: req.query.filter,
+      page: req.query.page,
+      limit: req.query.limit
+    });
+
+    const result = await RequestService.getRequestList(userId, dto);
+    const responseData = parseWithBigInt(stringifyWithBigInt(result));
+
+    res.status(StatusCodes.OK).success(responseData);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/request/dto/request.dto.js
+++ b/src/request/dto/request.dto.js
@@ -1,0 +1,9 @@
+// 신청함 목록 조회 DTO
+export class GetRequestListDto {
+  constructor({ filter = 'all', page = 1, limit = 10 }) {
+    this.filter = filter; // 'all' | 'ongoing' | 'completed'
+    this.page = parseInt(page);
+    this.limit = parseInt(limit);
+    this.offset = (this.page - 1) * this.limit;
+  }
+}

--- a/src/request/repository/request.repository.js
+++ b/src/request/repository/request.repository.js
@@ -1,11 +1,101 @@
 import { prisma } from "../../db.config.js"
 
 export const RequestRepository = {
-    async findRequestById(requestId) {
+  
+  /**
+   * 리퀘스트 Id 조회
+   */
+  async findRequestById(requestId) {
     return await prisma.request.findUnique({
       where: {
         id: requestId,
       },
+    });
+  },
+
+  /**
+   * 사용자의 신청 목록 조회 (필터링 포함)
+   */
+  async findRequestsByUserId(userId, filter, offset, limit) {
+    // 필터에 따른 상태 조건 설정
+    let statusCondition = {};
+    
+    if (filter === 'ongoing') { //상태: 진행중
+      statusCondition = {
+        status: { 
+          in: ['PENDING', 'APPROVED', 'IN_PROGRESS', 'SUBMITTED'] 
+        }
+      };
+    } else if (filter === 'completed') { //상태: 진행완료
+      statusCondition = {
+        status: 'COMPLETED'
+      };
+    }
+
+    return await prisma.request.findMany({
+      where: {
+        userId: BigInt(userId),
+        ...statusCondition
+      },
+      include: {
+        commission: {
+          select: {
+            id: true,
+            title: true,
+            minPrice: true,
+            artist: {
+              select: {
+                id: true,
+                nickname: true,
+              }
+            }
+          }
+        }
+      },
+      orderBy: { createdAt: 'desc' },
+      skip: offset,
+      take: limit
+    });
+  },
+
+  /**
+   * 사용자의 신청 총 개수 조회 (필터링 포함)
+   */
+  async countRequestsByUserId(userId, filter) {
+    let statusCondition = {};
+    
+    if (filter === 'ongoing') {
+      statusCondition = {
+        status: { 
+          in: ['PENDING', 'APPROVED', 'IN_PROGRESS', 'SUBMITTED'] 
+        }
+      };
+    } else if (filter === 'completed') {
+      statusCondition = {
+        status: 'COMPLETED'
+      };
+    }
+
+    return await prisma.request.count({
+      where: {
+        userId: BigInt(userId),
+        ...statusCondition
+      }
+    });
+  },
+
+  /**
+   * 커미션 ID들로 썸네일 이미지 조회
+   */
+  async findThumbnailImagesByCommissionIds(commissionIds) {
+    if (commissionIds.length === 0) return [];
+    
+    return await prisma.image.findMany({
+      where: {
+        target: 'commission',
+        targetId: { in: commissionIds },
+        orderIndex: 0
+      }
     });
   },
 };

--- a/src/request/request.routes.js
+++ b/src/request/request.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { getRequestList } from "./controller/request.controller.js";
+import { authenticate } from "../middlewares/auth.middleware.js";
+
+const router = Router();
+
+// 신청 목록 조회 API
+router.get('/', authenticate, getRequestList);
+
+export default router;

--- a/src/request/service/request.service.js
+++ b/src/request/service/request.service.js
@@ -1,0 +1,76 @@
+import { InvalidRequestFilterError } from "../../common/errors/request.errors.js";
+import { RequestRepository } from "../repository/request.repository.js";
+
+export const RequestService = {
+
+  /**
+   * 신청 목록 조회
+   */
+  async getRequestList(userId, dto) {
+    const { filter, offset, limit, page } = dto;
+
+    // 필터 유효성 검증
+    if (!['all', 'ongoing', 'completed'].includes(filter)) {
+      throw new InvalidRequestFilterError({ filter });
+    }
+
+    // 신청 목록 조회
+    const requests = await RequestRepository.findRequestsByUserId(userId, filter, offset, limit);
+    
+    // 총 개수 조회
+    const totalCount = await RequestRepository.countRequestsByUserId(userId, filter);
+    const totalPages = Math.ceil(totalCount / limit);
+
+    // 커미션 ID로 썸네일 이미지 조회
+    const commissionIds = requests.map(request => request.commission.id);
+    const thumbnailImages = await RequestRepository.findThumbnailImagesByCommissionIds(commissionIds);
+    
+    // 썸네일 이미지 매핑
+    const thumbnailMap = {};
+    thumbnailImages.forEach(image => {
+      thumbnailMap[image.targetId.toString()] = image.imageUrl;
+    });
+
+    // 진행률 계산 함수
+    const getProgressPercent = (status) => {
+      switch (status) {
+        case 'PENDING': return 0;
+        case 'APPROVED':
+        case 'IN_PROGRESS':
+        case 'SUBMITTED': return 50;
+        case 'COMPLETED': return 100;
+        case 'CANCELED':
+        case 'REJECTED': return null;
+        default: return null;
+      }
+    };
+
+    // 응답 데이터
+    const responseRequests = requests.map(request => ({
+      requestId: request.id,
+      status: request.status,
+      title: request.commission.title,
+      price: request.commission.minPrice,
+      thumbnailImageUrl: thumbnailMap[request.commission.id.toString()] || null,
+      progressPercent: getProgressPercent(request.status),
+      createdAt: request.createdAt.toISOString(),
+      artist: {
+        id: request.commission.artist.id,
+        nickname: request.commission.artist.nickname
+      },
+      commission: {
+        id: request.commission.id
+      }
+    }));
+
+    return {
+      requests: responseRequests,
+      pagination: {
+        page,
+        limit,
+        totalCount,
+        totalPages
+      }
+    };
+  },
+};

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,6 +8,7 @@ import commissionRouter from "./commission/commission.routes.js"
 import notificationRouter from "./notification/notification.routes.js";
 import paymentRouter from "./payment/payment.routes.js"
 import pointRouter from "./point/point.routes.js"
+import requestRouter from "./request/request.routes.js"
 
 const router = express.Router();
 
@@ -21,6 +22,7 @@ router.use("/requests", reviewRouter); // 임시 리뷰 작성 API
 router.use("/notifications", notificationRouter);
 router.use("/payments", paymentRouter);
 router.use("/points", pointRouter);
+router.use("/requests", requestRouter);
 
 // TODO: 커미션 신청 페이지 작업 완료되면 라우터 분리 예정
 // router.use("/requests", requestRouter);


### PR DESCRIPTION
## 📝 Description
<!-- 어떤 기능을 구현하거나 변경했는지 간단히 설명해 주세요 -->
로그인 사용자의 신청 목록을 조회
<!-- 이 PR이 해결하는 이슈 번호 (머지되면 해당 이슈가 자동으로 닫힙니다!) -->
Fixes #37

## ⚙️ Type
<!-- PR의 유형을 선택해 주세요. -->
- [x] 기능 추가 (새로운 API, 서비스 로직 등)
- [ ] 버그 수정 (예외 처리, 동작 오류 등)
- [ ] 리팩토링 (코드 정리, 로직 개선 등)
- [x] 문서 수정 (README, Swagger, 주석 등)
- [ ] 테스트 코드 추가/수정
- [ ] 의존성 추가/수정

## 📂 Summary of Changes
<!-- 어떤 파일을 수정했고 어떤 작업을 했는지 요약해 주세요. -->
- `src/request/*`: 신청함 목록 조회 API 구현
- `src/common/errors/request.errors.js`: 리퀘스트 관련 에러 클래스 추가
- `src/common/swagger/request.json`: 신청함 목록 조회 스웨거 문서화
- `src/routes.js`: 신청함 라우터 추가

## 👀 To Reviewer
<!-- 리뷰어가 꼭 봐줬으면 하는 부분이나 요청사항이 있다면 적어주세요 -->
<!-- 예: 유효성 검사 방식이 괜찮은지 확인 부탁드립니다 -->
진행률(progressPercent)은 상태별로 0/50/100/null 값을 반환하며, 취소/거절된 신청은 전체 필터에서만 조회 가능합니다.

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인해 주세요. -->
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 기능이 정상 동작하는지 테스트했습니다.
- [x] Swagger 문서를 최신 상태로 반영했습니다. (필요 시)