### PR TITLE
[FEAT] 팔로잉 작가 커미션 조회 API

### DIFF
--- a/src/common/swagger/home.json
+++ b/src/common/swagger/home.json
@@ -3,8 +3,8 @@
     "/api/home": {
       "get": {
         "tags": ["Home"],
-        "summary": "홈화면 데이터 조회",
-        "description": "홈화면에 표시될 6개 섹션의 데이터를 한 번에 조회합니다. (추천 커미션, 신규등록, 신청폭주, 마감임박, 최신 후기, 신규 작가)",
+        "summary": "홈 화면 조회",
+        "description": "홈화면에 표시될 6개 섹션의 데이터를 한 번에 조회합니다.",
         "security": [{ "bearerAuth": [] }],
         "responses": {
           "200": {
@@ -70,6 +70,60 @@
           }
         }
       }
+    },
+    "/api/home/following": {
+      "get": {
+        "tags": ["Home"],
+        "summary": "팔로잉 작가 커미션 조회",
+        "description": "사용자가 팔로우한 작가들의 커미션 게시글들을 타임라인 형태로 최신순 조회합니다.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "default": 1, "minimum": 1 },
+            "description": "페이지 번호"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "default": 10, "minimum": 1, "maximum": 50 },
+            "description": "페이지당 항목 수"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "팔로잉 작가 커미션 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "resultType": { "type": "string", "example": "SUCCESS" },
+                    "error": { "type": "null", "example": null },
+                    "success": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/FollowingCommissionItem"
+                          }
+                        },
+                        "pagination": {
+                          "$ref": "#/components/schemas/PaginationInfo"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -101,6 +155,41 @@
                 "nullable": true,
                 "example": "https://example.com/profile.jpg"
               }
+            }
+          }
+        }
+      },
+      "FollowingCommissionItem": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "example": 13 },
+          "title": { "type": "string", "example": "커미션 제목" },
+          "summary": { "type": "string", "example": "커미션 요약 텍스트" },
+          "images": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer", "example": 1 },
+                "imageUrl": { "type": "string", "example": "https://example.com/image1.jpg" },
+                "orderIndex": { "type": "integer", "example": 0 }
+              }
+            }
+          },
+          "timeAgo": { "type": "string", "example": "5분 전" },
+          "createdAt": { "type": "string", "format": "date-time", "example": "2025-07-23T10:30:00.000Z" },
+          "isBookmarked": { "type": "boolean", "example": false },
+          "artist": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "integer", "example": 1 },
+              "nickname": { "type": "string", "example": "작가1" },
+              "profileImageUrl": {
+                "type": "string",
+                "nullable": true,
+                "example": "https://cdn.example.com/artist1.jpg"
+              },
+              "followCount": { "type": "integer", "example": 245 }
             }
           }
         }
@@ -153,6 +242,15 @@
             "nullable": true,
             "example": "https://example.com/profile.jpg"
           }
+        }
+      },
+      "PaginationInfo": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "integer", "example": 1 },
+          "limit": { "type": "integer", "example": 10 },
+          "totalCount": { "type": "integer", "example": 25 },
+          "totalPages": { "type": "integer", "example": 3 }
         }
       }
     }

--- a/src/home/controller/home.controller.js
+++ b/src/home/controller/home.controller.js
@@ -1,5 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 import { HomeService } from '../service/home.service.js';
+import { GetFollowingCommissionsDto } from "../dto/home.dto.js";
 import { parseWithBigInt, stringifyWithBigInt } from "../../bigintJson.js";
 
 // 홈화면 데이터 조회
@@ -8,6 +9,24 @@ export const getHomeData = async (req, res, next) => {
     const userId = BigInt(req.user.userId);
     
     const result = await HomeService.getHomeData(userId);
+    const responseData = parseWithBigInt(stringifyWithBigInt(result));
+
+    res.status(StatusCodes.OK).success(responseData);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// 팔로잉 작가 커미션 조회
+export const getFollowingCommissions = async (req, res, next) => {
+  try {
+    const userId = BigInt(req.user.userId);
+    const dto = new GetFollowingCommissionsDto({
+      page: req.query.page,
+      limit: req.query.limit
+    });
+
+    const result = await HomeService.getFollowingCommissions(userId, dto);
     const responseData = parseWithBigInt(stringifyWithBigInt(result));
 
     res.status(StatusCodes.OK).success(responseData);

--- a/src/home/dto/home.dto.js
+++ b/src/home/dto/home.dto.js
@@ -1,5 +1,8 @@
-export class GetHomeDataDto {
-  constructor() {
-    this.limit = 6;
+// 팔로잉 작가 커미션 조회 DTO
+export class GetFollowingCommissionsDto {
+  constructor({ page = 1, limit = 10 }) {
+    this.page = parseInt(page);
+    this.limit = parseInt(limit);
+    this.offset = (this.page - 1) * this.limit;
   }
 }

--- a/src/home/home.routes.js
+++ b/src/home/home.routes.js
@@ -1,10 +1,16 @@
 import { Router } from 'express';
-import { getHomeData } from "./controller/home.controller.js";
+import { 
+    getHomeData,
+    getFollowingCommissions
+ } from "./controller/home.controller.js";
 import { authenticate } from "../middlewares/auth.middleware.js";
 
 const router = Router();
 
 // 홈화면 조회 API
 router.get('/', authenticate, getHomeData);
+
+// 팔로잉 작가 커미션 조회 API
+router.get('/following', authenticate, getFollowingCommissions);
 
 export default router;

--- a/src/home/repository/home.repository.js
+++ b/src/home/repository/home.repository.js
@@ -262,4 +262,75 @@ export const HomeRepository = {
       }
     });
   },
+
+  /**
+   * 사용자가 팔로우한 작가들의 커미션 목록 조회
+   */
+  async findFollowingCommissions(userId, offset, limit) {
+    return await prisma.commission.findMany({
+      where: {
+        artist: {
+          follows: {
+            some: {
+              userId: BigInt(userId)
+            }
+          }
+        }
+      },
+      include: {
+        artist: {
+          select: {
+            id: true,
+            nickname: true,
+            profileImage: true,
+            _count: {
+              select: {
+                follows: true
+              }
+            }
+          }
+        },
+        bookmarks: {
+          where: { userId: BigInt(userId) }
+        }
+      },
+      orderBy: {
+        createdAt: 'desc'
+      },
+      skip: offset,
+      take: limit
+    });
+  },
+
+  /**
+   * 사용자가 팔로우한 작가들의 커미션 총 개수 조회
+   */
+  async countFollowingCommissions(userId) {
+    return await prisma.commission.count({
+      where: {
+        artist: {
+          follows: {
+            some: {
+              userId: BigInt(userId)
+            }
+          }
+        }
+      }
+    });
+  },
+
+  /**
+   * 커미션 ID 목록으로 이미지 조회
+   */
+  async findImagesByCommissionIds(commissionIds) {
+    return await prisma.image.findMany({
+      where: {
+        target: 'commission',
+        targetId: {
+          in: commissionIds.map(id => BigInt(id))
+        }
+      },
+      orderBy: { orderIndex: 'asc' }
+    });
+  },
 };

--- a/src/home/service/home.service.js
+++ b/src/home/service/home.service.js
@@ -111,4 +111,87 @@ export const HomeService = {
       }))
     };
   },
+
+  /**
+   * 팔로잉 작가 커미션 조회
+   */
+  async getFollowingCommissions(userId, dto) {
+    const { offset, limit, page } = dto;
+
+    // 팔로잉 작가 커미션 목록 조회
+    const commissions = await HomeRepository.findFollowingCommissions(userId, offset, limit);
+    
+    // 총 개수 조회
+    const totalCount = await HomeRepository.countFollowingCommissions(userId);
+    
+    // 커미션 ID 목록으로 이미지 조회
+    const commissionIds = commissions.map(commission => commission.id);
+    const images = await HomeRepository.findImagesByCommissionIds(commissionIds);
+    
+    // 이미지를 커미션별로 그룹화
+    const imagesByCommissionId = images.reduce((acc, image) => {
+      const commissionId = image.targetId.toString();
+      if (!acc[commissionId]) acc[commissionId] = [];
+      acc[commissionId].push({
+        id: image.id,
+        imageUrl: image.imageUrl,
+        orderIndex: image.orderIndex
+      });
+      return acc;
+    }, {});
+
+    // timeago 계산 (KST 기준)
+    const calculateTimeAgo = (createdAt) => {
+      const now = new Date();
+      const kstNow = new Date(now.getTime() + (9 * 60 * 60 * 1000));
+      const kstCreatedAt = new Date(new Date(createdAt).getTime() + (9 * 60 * 60 * 1000));
+      
+      const diffMs = kstNow - kstCreatedAt;
+      const diffMinutes = Math.floor(diffMs / (1000 * 60));
+      const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      const diffMonths = Math.floor(diffDays / 30);
+
+      if (diffMinutes < 1) {
+        return "방금";
+      } else if (diffMinutes < 60) {
+        return `${diffMinutes}분 전`;
+      } else if (diffHours < 24) {
+        return `${diffHours}시간 전`;
+      } else if (diffDays < 30) {
+        return `${diffDays}일 전`;
+      } else {
+        return `${diffMonths}달 전`;
+      }
+    };
+
+    // 응답 데이터
+    const items = commissions.map(commission => ({
+      id: commission.id,
+      title: commission.title,
+      summary: commission.summary,
+      images: imagesByCommissionId[commission.id.toString()] || [],
+      timeAgo: calculateTimeAgo(commission.createdAt),
+      createdAt: commission.createdAt.toISOString(),
+      isBookmarked: commission.bookmarks?.length > 0 || false,
+      artist: {
+        id: commission.artist.id,
+        nickname: commission.artist.nickname,
+        profileImageUrl: commission.artist.profileImage,
+        followCount: commission.artist._count.follows
+      }
+    }));
+
+    const totalPages = Math.ceil(totalCount / limit);
+
+    return {
+      items,
+      pagination: {
+        page,
+        limit,
+        totalCount,
+        totalPages
+      }
+    };
+  },
 };


### PR DESCRIPTION
## 📝 Description
<!-- 어떤 기능을 구현하거나 변경했는지 간단히 설명해 주세요 -->
사용자가 팔로우한 작가들의 커미션 게시글들을 타임라인 형태로 조회하는 API입니다. 
<!-- 이 PR이 해결하는 이슈 번호 (머지되면 해당 이슈가 자동으로 닫힙니다!) -->
Fixes #58

## ⚙️ Type
<!-- PR의 유형을 선택해 주세요. -->
- [x] 기능 추가 (새로운 API, 서비스 로직 등)
- [ ] 버그 수정 (예외 처리, 동작 오류 등)
- [ ] 리팩토링 (코드 정리, 로직 개선 등)
- [x] 문서 수정 (README, Swagger, 주석 등)
- [ ] 테스트 코드 추가/수정
- [ ] 의존성 추가/수정

## 📂 Summary of Changes
<!-- 어떤 파일을 수정했고 어떤 작업을 했는지 요약해 주세요. -->
- `src/home/*`: 팔로잉 작가 커미션 조회 API 구현
- `src/common/swagger/home.json`: 팔로잉 작가 커미션 조회 API 스웨거 문서화

## 👀 To Reviewer
<!-- 리뷰어가 꼭 봐줬으면 하는 부분이나 요청사항이 있다면 적어주세요 -->
<!-- 예: 유효성 검사 방식이 괜찮은지 확인 부탁드립니다 -->
테스트 완료했습니다
<img width="1064" height="1128" alt="image" src="https://github.com/user-attachments/assets/7716df2e-a397-46f5-9675-0446c70d8873" />

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인해 주세요. -->
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 기능이 정상 동작하는지 테스트했습니다.
- [x] Swagger 문서를 최신 상태로 반영했습니다. (필요 시)