### PR TITLE
[FEAT] 결제 내역 조회

### DIFF
--- a/prisma/migrations/20250723130401_add_point_amount_to_payment/migration.sql
+++ b/prisma/migrations/20250723130401_add_point_amount_to_payment/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `payments` ADD COLUMN `point_amount` INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20250723155205_add_total_price_to_request/migration.sql
+++ b/prisma/migrations/20250723155205_add_total_price_to_request/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[imp_uid]` on the table `payments` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `total_price` to the `requests` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `requests` ADD COLUMN `total_price` INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `payments_imp_uid_key` ON `payments`(`imp_uid`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -142,8 +142,9 @@ model Payment {
   productId   BigInt   @map("product_id")
   pgProvider  String   @map("pg_provider") @db.VarChar(100)
   price       Int
+  pointAmount Int      @map("point_amount") @default(0)
   status      String   @db.VarChar(20)
-  impUid      String   @map("imp_uid") @db.VarChar(100)
+  impUid      String   @unique @map("imp_uid") @db.VarChar(100)
   merchantUid String   @map("merchant_uid") @db.VarChar(100)
   createdAt   DateTime @default(now()) @map("created_at")
 

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -79,6 +79,7 @@ async function main() {
     data: {
       userId: user2.id,
       commissionId: commission.id,
+      totalPrice: 0,
       status: "PENDING", // enum값
       formAnswer: {
         detail: "테스트 커미션 요청 상세 설명입니다.",

--- a/src/common/errors/payment.errors.js
+++ b/src/common/errors/payment.errors.js
@@ -21,3 +21,14 @@ export class PaymentAmountMismatchError extends BaseError {
     });
   }
 }
+
+export class DuplicatePaymentError extends BaseError {
+  constructor(data = null) {
+    super({
+      errorCode: "P003",
+      reason: "이미 결제된 거래입니다.",
+      statusCode: 400,
+      data,
+    });
+  }
+}

--- a/src/common/swagger/payment.json
+++ b/src/common/swagger/payment.json
@@ -13,7 +13,6 @@
                 "$ref": "#/components/schemas/PaymentCompleteRequest"
               },
               "example": {
-                "requestId": 1,
                 "userId": 1,
                 "productId": 1,
                 "impUid": "imp_1234567890"
@@ -88,6 +87,72 @@
           }
         }
       }
+    },
+    "/api/payments": {
+      "get": {
+        "summary": "결제 내역 조회",
+        "description": "사용자의 결제 내역을 조회합니다.",
+        "tags": ["Payment"],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "결제 내역 조회 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentListResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "결제 내역 조회 성공 예시",
+                    "value": {
+                      "resultType": "SUCCESS",
+                      "error": null,
+                      "success": [
+                        {
+                          "id": 1,
+                          "userId": 5,
+                          "amount": 10000,
+                          "status": "PAID",
+                          "method": "kakao_pay",
+                          "createdAt": "2025-07-23T12:00:00Z",
+                          "updatedAt": "2025-07-23T12:00:00Z"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "JWT 인증 실패 (Unauthorized)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "resultType": "FAIL",
+                  "error": {
+                    "errorCode": "AUTH001",
+                    "reason": "유효하지 않은 토큰입니다.",
+                    "data": null
+                  },
+                  "success": null
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 오류"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -95,32 +160,16 @@
       "PaymentCompleteRequest": {
         "type": "object",
         "properties": {
-          "requestId": {
-            "type": "integer",
-            "description": "Request 테이블 ID"
-          },
-          "userId": {
-            "type": "integer",
-            "description": "User ID"
-          },
-          "productId": {
-            "type": "integer",
-            "description": "Product ID"
-          },
-          "impUid": {
-            "type": "string",
-            "description": "아임포트 imp_uid"
-          }
+          "userId": { "type": "integer" },
+          "productId": { "type": "integer" },
+          "impUid": { "type": "string" }
         },
-        "required": ["requestId", "userId", "productId", "impUid"]
+        "required": ["userId", "productId", "impUid"]
       },
       "PaymentCompleteResponse": {
         "type": "object",
         "properties": {
-          "resultType": {
-            "type": "string",
-            "example": "SUCCESS"
-          },
+          "resultType": { "type": "string", "example": "SUCCESS" },
           "success": {
             "type": "object",
             "properties": {
@@ -136,8 +185,36 @@
               "pointBalance": { "type": "integer" }
             }
           },
-          "error": {
-            "type": ["object", "null"]
+          "error": { "type": ["object", "null"] }
+        }
+      },
+      "PaymentListResponse": {
+        "type": "object",
+        "properties": {
+          "resultType": { "type": "string", "example": "SUCCESS" },
+          "error": { "type": "object", "nullable": true, "example": null },
+          "success": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer", "example": 1 },
+                "userId": { "type": "integer", "example": 5 },
+                "amount": { "type": "integer", "example": 10000 },
+                "status": { "type": "string", "example": "PAID" },
+                "method": { "type": "string", "example": "kakao_pay" },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2025-07-23T12:00:00Z"
+                },
+                "updatedAt": {
+                  "type": "string",
+                  "format": "date-time",
+                  "example": "2025-07-23T12:00:00Z"
+                }
+              }
+            }
           }
         }
       },
@@ -153,10 +230,15 @@
               "data": { "type": ["object", "null"] }
             }
           },
-          "success": {
-            "type": ["object", "null"]
-          }
+          "success": { "type": ["object", "null"] }
         }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/src/payment/controller/payment.controller.js
+++ b/src/payment/controller/payment.controller.js
@@ -19,3 +19,15 @@ export const paymentConfirm = async (req, res, next) => {
       next(err);
     }
 }
+
+export const getPayments = async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+
+    const payments = await PaymentService.getPayments(userId);
+    const responseData = parseWithBigInt(stringifyWithBigInt(payments));
+    res.status(StatusCodes.OK).success(responseData);
+  } catch(err) {
+    next(err);
+  }
+}

--- a/src/payment/payment.routes.js
+++ b/src/payment/payment.routes.js
@@ -1,8 +1,14 @@
 import express from "express";
 import { paymentConfirm } from "./controller/payment.controller.js";
+import { getPayments } from "./controller/payment.controller.js";
+import { authenticate } from "../middlewares/auth.middleware.js";
 
 const router = express.Router();
 
+// 결제 정보 저장 API
 router.post("/complete", paymentConfirm);
+
+// 결제 정보 조회 API
+router.get("", authenticate, getPayments);
 
 export default router;

--- a/src/payment/repository/payment.repository.js
+++ b/src/payment/repository/payment.repository.js
@@ -13,6 +13,7 @@ export const PaymentRepository = {
         userId: BigInt(data.userId),
         productId: BigInt(data.productId),
         price: data.price,
+        pointAmount: data.pointAmount,
         status: data.status,
         impUid: data.impUid,
         merchantUid: data.merchantUid,
@@ -20,4 +21,17 @@ export const PaymentRepository = {
       },
     });
   },
+
+  async getPaymentByImpUid(impUid) {
+    return await prisma.payment.findUnique({
+      where: { impUid },
+    });
+  },
+
+  async getPayments(userId) {
+    return await prisma.payment.findMany({
+      where: { userId },
+      orderBy: { createdAt: "desc" },
+    });
+  } 
 };

--- a/src/payment/service/payment.service.js
+++ b/src/payment/service/payment.service.js
@@ -3,6 +3,7 @@ import { PaymentRepository } from "../repository/payment.repository.js";
 import { PointRepository } from "../../point/repository/point.repository.js";
 import { ProductNotFoundError } from "../../common/errors/payment.errors.js";
 import { PaymentAmountMismatchError } from "../../common/errors/payment.errors.js";
+import { DuplicatePaymentError } from "../../common/errors/payment.errors.js";
 
 export const PaymentService = {
   async createPayment(dto) {
@@ -19,6 +20,11 @@ export const PaymentService = {
     });
     const paymentData = paymentDataRes.data.response;
 
+    const existingPayment = await PaymentRepository.getPaymentByImpUid(paymentData.imp_uid);
+    if (existingPayment) {
+      throw new DuplicatePaymentError({ impUid: paymentData.imp_uid });
+    }
+
     // DB에서 product 가격 조회
     const product = await PaymentRepository.getProductById(dto.productId);
     if (!product) {
@@ -34,6 +40,7 @@ export const PaymentService = {
     const savedPayment = await PaymentRepository.createPayment({
       ...dto,
       price: paymentData.amount,
+      pointAmount: product.point,
       status: paymentData.status,
       impUid: paymentData.imp_uid,
       merchantUid: paymentData.merchant_uid,
@@ -63,4 +70,10 @@ export const PaymentService = {
 
     return savedPayment;
   },
+
+  async getPayments(userId) {
+    const payments = PaymentRepository.getPayments(userId);
+
+    return payments;
+  }
 };


### PR DESCRIPTION
## 📝 Description
<!-- 어떤 기능을 구현하거나 변경했는지 간단히 설명해 주세요 -->
사용자가 포인트 구매를 위해 결제한 내역을 조회합니다.
<!-- 이 PR이 해결하는 이슈 번호 (머지되면 해당 이슈가 자동으로 닫힙니다!) -->
Fixes #69
<!-- 관련된 이슈 번호 (자동 닫힘 X) -->
Related #이슈번호

## ⚙️ Type
<!-- PR의 유형을 선택해 주세요. -->
- [x] 기능 추가 (새로운 API, 서비스 로직 등)
- [x] 버그 수정 (예외 처리, 동작 오류 등)
- [x] 리팩토링 (코드 정리, 로직 개선 등)
- [x] 문서 수정 (README, Swagger, 주석 등)
- [ ] 테스트 코드 추가/수정
- [ ] 의존성 추가/수정

## 📂 Summary of Changes
<!-- 어떤 파일을 수정했고 어떤 작업을 했는지 요약해 주세요. -->
- payment 관련 이미 처리된 거래의 경우 중복 처리되지 않도록 unique 옵션을 추가했습니다.
- `src/payment`내 결제 조회 기능을 구현했습니다.
- payment 테이블내 구매한 포인트의 양을 추가했습니다(point_amount)
- total_price 컬럼 db 추가 후 seed.js파일에 수정해두었습니다.
## 👀 To Reviewer
<!-- 리뷰어가 꼭 봐줬으면 하는 부분이나 요청사항이 있다면 적어주세요 -->
<!-- 예: 유효성 검사 방식이 괜찮은지 확인 부탁드립니다 -->

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인해 주세요. -->
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 기능이 정상 동작하는지 테스트했습니다.
- [x] Swagger 문서를 최신 상태로 반영했습니다. (필요 시)