### PR TITLE
[FIX] 팔로우 관계 조회 시 accountId를 사용하도록 수정

### DIFF
--- a/src/commission/repository/commission.repository.js
+++ b/src/commission/repository/commission.repository.js
@@ -128,7 +128,7 @@ export const CommissionRepository = {
         userId: BigInt(userId),
         commissionId: BigInt(commissionId),
         status: {
-          notIn: ['CANCELED', 'REJECTED', 'COMPLETED']  // 취소/거절/완료된 것은 제외 (재신청 가능)
+          notIn: ['CANCELED', 'REJECTED', 'COMPLETED']
         }
       }
     });
@@ -149,6 +149,15 @@ export const CommissionRepository = {
    * 커미션 ID로 작가 정보 조회 (팔로우 여부 포함)
    */
   async findArtistInfoByCommissionId(commissionId, userId) {
+    let userAccountId = null;
+    if (userId) {
+      const user = await prisma.user.findUnique({
+        where: { id: BigInt(userId) },
+        select: { accountId: true }
+      });
+      userAccountId = user?.accountId;
+    }
+
     return await prisma.commission.findUnique({
       where: {
         id: BigInt(commissionId)
@@ -156,8 +165,8 @@ export const CommissionRepository = {
       include: {
         artist: {
           include: {
-            follows: userId ? {
-              where: { userId: BigInt(userId) }
+            follows: userAccountId ? {
+              where: { accountId: BigInt(userAccountId) }
             } : false
           }
         }
@@ -277,61 +286,61 @@ export const CommissionRepository = {
   },
 
   /**
-	 * 특정 월에 승인받은 사용자의 리퀘스트 조회 (커미션 리포트용)
-	 */
-	async findApprovedRequestsByUserAndMonth(userId, year, month) {
-		const startDate = new Date(year, month - 1, 1);
-		const endDate = new Date(year, month, 1);
+   * 특정 월에 승인받은 사용자의 리퀘스트 조회 (커미션 리포트용)
+   */
+  async findApprovedRequestsByUserAndMonth(userId, year, month) {
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 1);
 
-		return await prisma.request.findMany({
-			where: {
-				userId: BigInt(userId),
-				approvedAt: {
-					gte: startDate,
-					lt: endDate
-				}
-			},
-			include: {
-				commission: {
-					select: {
-						id: true,
-						categoryId: true,
-						artist: {
-							select: {
-								id: true,
-								nickname: true,
-								profileImage: true
-							}
-						},
-						category: {
-							select: {
-								name: true
-							}
-						}
-					}
-				},
-				reviews: {
-					select: {
-						id: true
-					}
-				}
-			}
-		});
-	},
+    return await prisma.request.findMany({
+      where: {
+        userId: BigInt(userId),
+        approvedAt: {
+          gte: startDate,
+          lt: endDate
+        }
+      },
+      include: {
+        commission: {
+          select: {
+            id: true,
+            categoryId: true,
+            artist: {
+              select: {
+                id: true,
+                nickname: true,
+                profileImage: true
+              }
+            },
+            category: {
+              select: {
+                name: true
+              }
+            }
+          }
+        },
+        reviews: {
+          select: {
+            id: true
+          }
+        }
+      }
+    });
+  },
 
-	/**
-	 * 사용자 닉네임 조회
-	 */
-	async findUserNicknameById(userId) {
-		const user = await prisma.user.findUnique({
-			where: {
-				id: BigInt(userId)
-			},
-			select: {
-				nickname: true
-			}
-		});
-		
-		return user?.nickname || null;
-	}
+  /**
+   * 사용자 닉네임 조회
+   */
+  async findUserNicknameById(userId) {
+    const user = await prisma.user.findUnique({
+      where: {
+        id: BigInt(userId)
+      },
+      select: {
+        nickname: true
+      }
+    });
+    
+    return user?.nickname || null;
+  }
 }

--- a/src/search/repository/search.repository.js
+++ b/src/search/repository/search.repository.js
@@ -72,37 +72,45 @@ export class SearchRepository {
       where.deadline = { lte: deadlineValue };
     }
 
-    // 팔로잉 필터 - AND 조건이 있으면 배열에 추가, 없으면 바로 설정
+    // 팔로잉 필터 - userId를 accountId로 변환
     if (followingOnly && userId) {
-      const followCondition = {
-        artist: {
-          follows: {
-            some: {
-              userId: userId
-            }
-          }
-        }
-      };
+      // user.id로 account_id 조회
+      const user = await prisma.user.findUnique({
+        where: { id: BigInt(userId) },
+        select: { accountId: true }
+      });
 
-      if (where.AND) {
-        // 태그 검색 + 팔로잉 필터
-        where.AND.push(followCondition);
-      } else if (where.artist) {
-        // 작가 검색 + 팔로잉 필터
-        where.artist.follows = {
-          some: {
-            userId: userId
-          }
-        };
-      } else {
-        // 팔로잉 필터만
-        where.artist = {
-          follows: {
-            some: {
-              userId: userId
+      if (user) {
+        const followCondition = {
+          artist: {
+            follows: {
+              some: {
+                accountId: BigInt(user.accountId)
+              }
             }
           }
         };
+
+        if (where.AND) {
+          // 태그 검색 + 팔로잉 필터
+          where.AND.push(followCondition);
+        } else if (where.artist) {
+          // 작가 검색 + 팔로잉 필터
+          where.artist.follows = {
+            some: {
+              accountId: BigInt(user.accountId)
+            }
+          };
+        } else {
+          // 팔로잉 필터만
+          where.artist = {
+            follows: {
+              some: {
+                accountId: BigInt(user.accountId)
+              }
+            }
+          };
+        }
       }
     }
 
@@ -121,6 +129,16 @@ export class SearchRepository {
         break;
     }
 
+    // userId를 accountId로 변환 (팔로우 상태 확인용)
+    let userAccountId = null;
+    if (userId) {
+      const user = await prisma.user.findUnique({
+        where: { id: BigInt(userId) },
+        select: { accountId: true }
+      });
+      userAccountId = user?.accountId;
+    }
+
     // 데이터 조회
     const [commissions, totalCount] = await Promise.all([
       prisma.commission.findMany({
@@ -137,9 +155,9 @@ export class SearchRepository {
               id: true,
               nickname: true,
               profileImage: true,
-              ...(userId && {
+              ...(userAccountId && {
                 follows: {
-                  where: { userId },
+                  where: { accountId: BigInt(userAccountId) },
                   select: { id: true }
                 }
               })
@@ -174,7 +192,7 @@ export class SearchRepository {
 
     const bookmarks = await prisma.bookmark.findMany({
       where: {
-        userId: userId,
+        userId: BigInt(userId),
         commissionId: { in: commissionIds }
       },
       select: { commissionId: true }
@@ -192,7 +210,7 @@ export class SearchRepository {
    */
   static async categoryExists(categoryId) {
     const category = await prisma.category.findUnique({
-      where: { id: categoryId }
+      where: { id: BigInt(categoryId) }
     });
     return !!category;
   }
@@ -235,7 +253,7 @@ export class SearchRepository {
     // 동일한 검색어가 이미 있으면 삭제 후 새로 추가 (최신 순 유지)
     await prisma.searchHistory.deleteMany({
       where: {
-        userId: userId,
+        userId: BigInt(userId),
         keyword: keyword
       }
     });
@@ -243,14 +261,14 @@ export class SearchRepository {
     // 새 검색어 저장
     await prisma.searchHistory.create({
       data: {
-        userId: userId,
+        userId: BigInt(userId),
         keyword: keyword
       }
     });
 
     // 최대 10개까지만 유지 (오래된 검색어 삭제)
     const searchHistories = await prisma.searchHistory.findMany({
-      where: { userId: userId },
+      where: { userId: BigInt(userId) },
       orderBy: { createdAt: 'desc' },
       skip: 10 // 최신 10개를 제외한 나머지
     });
@@ -270,7 +288,7 @@ export class SearchRepository {
    */
   static async getRecentSearches(userId, limit = 10) {
     return await prisma.searchHistory.findMany({
-      where: { userId: userId },
+      where: { userId: BigInt(userId) },
       orderBy: { createdAt: 'desc' },
       take: limit,
       select: {
@@ -287,7 +305,7 @@ export class SearchRepository {
   static async deleteRecentSearch(userId, keyword) {
     await prisma.searchHistory.deleteMany({
       where: {
-        userId: userId,
+        userId: BigInt(userId),
         keyword: keyword
       }
     });
@@ -298,7 +316,7 @@ export class SearchRepository {
    */
   static async deleteAllRecentSearches(userId) {
     await prisma.searchHistory.deleteMany({
-      where: { userId: userId }
+      where: { userId: BigInt(userId) }
     });
   }
 }


### PR DESCRIPTION
## 📝 Description
<!-- 어떤 기능을 구현하거나 변경했는지 간단히 설명해 주세요 -->
커미션 작가 정보 API와 검색 API의 팔로우 관계 조회 시 userId 대신 accountId를 사용하도록 수정했습니다

## ⚙️ Type
<!-- PR의 유형을 선택해 주세요. -->
- [ ] 기능 추가 (새로운 API, 서비스 로직 등)
- [x] 버그 수정 (예외 처리, 동작 오류 등)
- [ ] 리팩토링 (코드 정리, 로직 개선 등)
- [ ] 문서 수정 (README, Swagger, 주석 등)
- [ ] 테스트 코드 추가/수정
- [ ] 의존성 추가/수정

## 📂 Summary of Changes
<!-- 어떤 파일을 수정했고 어떤 작업을 했는지 요약해 주세요. -->
- `src/commission/repository/commission.repository.js`
- `src/search/repository/search.repository.js`

## 👀 To Reviewer
<!-- 리뷰어가 꼭 봐줬으면 하는 부분이나 요청사항이 있다면 적어주세요 -->
<!-- 예: 유효성 검사 방식이 괜찮은지 확인 부탁드립니다 -->

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인해 주세요. -->
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 코드 컨벤션을 준수했습니다.
- [x] 기능이 정상 동작하는지 테스트했습니다.
- [ ] Swagger 문서를 최신 상태로 반영했습니다. (필요 시)